### PR TITLE
Fix memset invocation in Session::Read

### DIFF
--- a/Herobrine/Session.cpp
+++ b/Herobrine/Session.cpp
@@ -29,7 +29,7 @@ void Session::Write(const string& buf)
 
 void Session::Read()
 {
-	memset(buffer, sizeof(buffer), '\0');
+	memset(buffer, '\0', sizeof(buffer));
 	sock.async_read_some(asio::buffer(buffer), boost::bind(&Session::OnRead, this, asio::placeholders::error, asio::placeholders::bytes_transferred));
 }
 


### PR DESCRIPTION
The `void *memset(void *s, int c, size_t n)` function takes the value to fill in its 2nd argument and the number of byte to fill in in 3rd.

This commit fixes an invalid use of `memset` which had the two arguments swapped and it did not set any memory at all in the end due to that.